### PR TITLE
Update build workflow with user guide

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -33,3 +33,19 @@ jobs:
         with:
           name: template.log
           path: ./template.log
+
+      - name: Build user guide
+        run: latexmk -pdflua manual/moderncv_userguide.tex
+
+      - name: Upload user guide pdf
+        uses: actions/upload-artifact@v4
+        with:
+          name: moderncv_userguide.pdf
+          path: manual/moderncv_userguide.pdf
+
+      - name: Upload user guide log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: moderncv_userguide.log
+          path: manual/moderncv_userguide.log


### PR DESCRIPTION
## Summary
- build `manual/moderncv_userguide.tex`
- upload the produced user guide PDF and log artifacts

## Testing
- `latexmk --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454d91400c832a839c2ca825815dc1